### PR TITLE
fix(manage.py): clear default cpp_info.{lib,include}dirs if package i…

### DIFF
--- a/conanfile_base.py
+++ b/conanfile_base.py
@@ -19,6 +19,8 @@ class BaseHeaderOnly(ConanFile):
             self.cpp_info.names['pkg_config'] = self.name[3:]
         self.cpp_info.builddirs.extend([os.path.join("share", "pkgconfig"),
                                         os.path.join("lib", "pkgconfig")])
+        self.cpp_info.includedirs = [path for path in self.cpp_info.includedirs if os.path.isdir(path)]
+        self.cpp_info.libdirs = [path for path in self.cpp_info.libdirs if os.path.isdir(path)]
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
…s headers_only

Default cpp_info.libdirs is "lib" and default cpp_info.includedirs
is "include". When pkg_config generator is used by package consumer,
<package_dir>/lib and <package_dir>/include is set as Libs and CFlags
entry in .pc file. And meticulous build script, like webengine one,
check if this directories exists. So we have to remove default
cpp_info.libdirs for headers only package, and remove default
cpp_info.includedirs for package whitout "include" directory.